### PR TITLE
[BUGFIX] Avoid variables conflict in merged TCA

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -91,3 +91,4 @@ $GLOBALS['TCA']['sys_file_metadata']['palettes']['access'] = [
 foreach ($GLOBALS['TCA']['sys_file_metadata']['types'] as &$configuration) {
     $configuration['showitem'] = str_replace('fe_groups,', '--palette--;;access,', $configuration['showitem']);
 }
+unset($configuration);


### PR DESCRIPTION
Hi,

If per example `news` is installed, there is a potential conflict between variable in the merged TCA.
Indeed, news use also a var named `$configuration` in is overridden TCA.

This patch unset the var `$configuration` after using it in the TCA of `sys_file_metadata`.

Thanks.