### PR TITLE
Handle processed files with original rights

### DIFF
--- a/Classes/Middleware/FileMiddleware.php
+++ b/Classes/Middleware/FileMiddleware.php
@@ -116,6 +116,9 @@ class FileMiddleware implements MiddlewareInterface, LoggerAwareInterface
         // This check is supposed to never succeed if the processed folder is properly
         // checked at the Web Server level to allow direct access
         if ($file->getStorage()->isWithinProcessingFolder($file->getIdentifier())) {
+            if ($file instanceof \TYPO3\CMS\Core\Resource\ProcessedFile) {
+                return $this->isFileAccessible($file->getOriginalFile(), $user, $maxAge);
+            }
             return true;
         }
 

--- a/Documentation/AdministratorManual/Index.rst
+++ b/Documentation/AdministratorManual/Index.rst
@@ -92,6 +92,10 @@ freely accessible. The rules above exclude this directory from useless
 processing by TYPO3 but even if you ask to process absolutely everything by
 this extension, files within the "_processed_" folder are always public.
 
+NOTE: Since version > 1.2.0 all ProcessedFiles are resolved to the original FAL 
+resource. As result you can also protect the "_processed_" folder, if the 
+resolution of the original file rights is correct for your purpose.
+
 
 Recycler
 ^^^^^^^^

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -44,6 +44,10 @@ By design, the "_processed_" folder (:file:`/fileadmin/_processed_/`) is not
 protected and its content (thumbnails or resized/cropped images) is always
 freely accessible.
 
+NOTE: Since version > 1.2.0 all ProcessedFiles are resolved to the original FAL 
+resource. As result you can also protect the "_processed_" folder, if the 
+resolution of the original file rights is correct for your purpose.
+
 
 .. _alternatives:
 


### PR DESCRIPTION
With this patch, processed files are also handled. You have to remove the "no processed" part in the rewrite rule. A processed files will be checked by the access control of the original source.