### PR TITLE
Create a real Response to keep the middleware stack consistent

### DIFF
--- a/Classes/Middleware/FileMiddleware.php
+++ b/Classes/Middleware/FileMiddleware.php
@@ -16,7 +16,7 @@ declare(strict_types=1);
 
 namespace Causal\FalProtect\Middleware;
 
-use Causal\FalProtect\Domain\Repository\FolderRepository;
+use Causal\FalProtect\Stream\FileStream;
 use Causal\FalProtect\Utility\AccessSecurity;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,10 +24,8 @@ use Psr\Http\Server\MiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
-use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Http\ImmediateResponseException;
 use TYPO3\CMS\Core\Http\Response;
-use TYPO3\CMS\Core\Http\Stream;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -80,27 +78,24 @@ class FileMiddleware implements MiddlewareInterface, LoggerAwareInterface
 
             $fileName = $file->getForLocalProcessing(false);
 
-            /**
-             * Note: we cannot return a standard PSR response as
-             * @see \TYPO3\CMS\Core\Http\AbstractApplication::sendResponse()
-             * will load all the content into memory using $body->__toString()
-             */
-            header('Content-Type: ' . $file->getMimeType());
+            $headers = [];
+            $headers['Content-Type'] = $file->getMimeType();
             if ($maxAge > 0) {
-                header('Cache-Control: public, max-age=' . $maxAge);
+                $headers['Cache-Control'] = 'public, max-age=' . $maxAge;
             } else {
-                header('Cache-Control: ' . implode(', ', [
+                $headers['Cache-Control'] = implode(', ', [
                     'no-store',
                     'no-cache',
                     'must-revalidate',
                     'max-age=0',
                     'post-check=0',
                     'pre-check=0',
-                ]));
-                header('Pragma: no-cache');
+                ]);
+                $headers['Pragma'] = 'no-cache';
             }
 
-            $this->handlePartialDownload($fileName);
+            $stream = new FileStream($fileName);
+            return new Response($stream, 200, $headers);
         }
 
         return $handler->handle($request);
@@ -170,92 +165,6 @@ class FileMiddleware implements MiddlewareInterface, LoggerAwareInterface
         }
 
         return false;
-    }
-
-    /**
-     * @param string $fileName
-     * @see https://www.techstruggles.com/mp3-streaming-for-apple-iphone-with-php-readfile-file_get_contents-fail/
-     */
-    protected function handlePartialDownload(string $fileName): void
-    {
-        $fp = fopen($fileName, 'rb');
-
-        $size   = filesize($fileName); // File size
-        $length = $size;               // Content length
-        $start  = 0;                   // Start byte
-        $end    = $size - 1;           // End byte
-
-        if (isset($_SERVER['HTTP_RANGE'])) {
-            // Extract the range string
-            list(, $range) = explode('=', $_SERVER['HTTP_RANGE'], 2);
-            // Make sure the client has not sent us a multibyte range
-            if (strpos($range, ',') !== false) {
-                // TODO: Should this be issued here, or should the first
-                // range be used? Or should the header be ignored and
-                // we output the whole content?
-                header('HTTP/1.1 416 Requested Range Not Satisfiable');
-                header('Content-Range: bytes ' . sprintf('%s-%s/%s', $start, $end, $size));
-                // TODO: Echo some info to the client?
-                exit;
-            }
-
-            // If the range starts with an '-' we start from the beginning
-            // If not, we forward the file pointer
-            // and make sure to get the end byte if specified
-            if (substr($range, 0, 1) === '-') {
-                // The n-number of the last bytes is requested
-                $c_start = $size - (int)substr($range, 1);
-                $c_end   = $end;
-            } else {
-                $range   = explode('-', $range);
-                $c_start = (int)$range[0];
-                $c_end   = !empty($range[1] ?? '') ? (int)$range[1] : $size;
-            }
-
-            /* Check the range and make sure it is treated according to the specs.
-             * https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-             */
-            // End bytes can not be larger than $end.
-            $c_end = ($c_end > $end) ? $end : $c_end;
-            // Validate the requested range and return an error if it is incorrect
-            if ($c_start > $c_end || $c_start > $size - 1 || $c_end >= $size) {
-                header('HTTP/1.1 416 Requested Range Not Satisfiable');
-                header('Content-Range: bytes ' . sprintf('%s-%s/%s', $start, $end, $size));
-                // TODO: Echo some info to the client?
-                exit;
-            }
-
-            $start  = $c_start;
-            $end    = $c_end;
-            $length = $end - $start + 1; // Calculate new content length
-            fseek($fp, $start);
-            header('HTTP/1.1 206 Partial Content');
-            // Notify the client the byte range we'll be outputting
-            header('Content-Range: bytes ' . sprintf('%s-%s/%s', $start, $end, $size));
-        }
-
-        header('Content-Length: ' . $length);
-        header('Accept-Ranges: bytes');
-
-        // Try to reset time limit for big files
-        set_time_limit(0);
-
-        // Start buffered download (chunks of 8K)
-        $buffer = 1024 * 8;
-        while (!feof($fp) && ($p = ftell($fp)) <= $end) {
-            if ($p + $buffer > $end) {
-                // In case we are only outputting a chunk, make sure we do not
-                // read past the length
-                $buffer = $end - $p + 1;
-            }
-            echo fread($fp, $buffer);
-
-            // Free up memory, otherwise large files will trigger PHP's memory limit
-            flush();
-        }
-
-        fclose($fp);
-        exit;
     }
 
     protected function pageNotFoundAction(ServerRequestInterface $request, string $message = 'Not Found'): void

--- a/Classes/Stream/FileStream.php
+++ b/Classes/Stream/FileStream.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Causal\FalProtect\Stream;
+
+use TYPO3\CMS\Core\Http\SelfEmittableLazyOpenStream;
+
+class FileStream extends SelfEmittableLazyOpenStream
+{
+    /**
+     * @return void
+     * @see https://www.techstruggles.com/mp3-streaming-for-apple-iphone-with-php-readfile-file_get_contents-fail/
+     */
+    public function emit()
+    {
+        $fp = fopen($this->filename, 'rb');
+
+        $size = filesize($this->filename); // File size
+        $length = $size;               // Content length
+        $start = 0;                   // Start byte
+        $end = $size - 1;           // End byte
+
+        if (isset($_SERVER['HTTP_RANGE'])) {
+            // Extract the range string
+            list(, $range) = explode('=', $_SERVER['HTTP_RANGE'], 2);
+            // Make sure the client has not sent us a multibyte range
+            if (strpos($range, ',') !== false) {
+                // TODO: Should this be issued here, or should the first
+                // range be used? Or should the header be ignored and
+                // we output the whole content?
+                header('HTTP/1.1 416 Requested Range Not Satisfiable');
+                header('Content-Range: bytes ' . sprintf('%s-%s/%s', $start, $end, $size));
+                // TODO: Echo some info to the client?
+                return;
+            }
+
+            // If the range starts with an '-' we start from the beginning
+            // If not, we forward the file pointer
+            // and make sure to get the end byte if specified
+            if (substr($range, 0, 1) === '-') {
+                // The n-number of the last bytes is requested
+                $c_start = $size - (int) substr($range, 1);
+                $c_end = $end;
+            } else {
+                $range = explode('-', $range);
+                $c_start = (int) $range[0];
+                $c_end = !empty($range[1] ?? '') ? (int) $range[1] : $size;
+            }
+
+            /* Check the range and make sure it is treated according to the specs.
+             * https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+             */
+            // End bytes can not be larger than $end.
+            $c_end = ($c_end > $end) ? $end : $c_end;
+            // Validate the requested range and return an error if it is incorrect
+            if ($c_start > $c_end || $c_start > $size - 1 || $c_end >= $size) {
+                header('HTTP/1.1 416 Requested Range Not Satisfiable');
+                header('Content-Range: bytes ' . sprintf('%s-%s/%s', $start, $end, $size));
+                // TODO: Echo some info to the client?
+                return;
+            }
+
+            $start = $c_start;
+            $end = $c_end;
+            $length = $end - $start + 1; // Calculate new content length
+            fseek($fp, $start);
+            header('HTTP/1.1 206 Partial Content');
+            // Notify the client the byte range we'll be outputting
+            header('Content-Range: bytes ' . sprintf('%s-%s/%s', $start, $end, $size));
+        }
+
+        header('Content-Length: ' . $length);
+        header('Accept-Ranges: bytes');
+
+        // Try to reset time limit for big files
+        set_time_limit(0);
+
+        // Start buffered download (chunks of 8K)
+        $buffer = 1024 * 8;
+        while (!feof($fp) && ($p = ftell($fp)) <= $end) {
+            if ($p + $buffer > $end) {
+                // In case we are only outputting a chunk, make sure we do not
+                // read past the length
+                $buffer = $end - $p + 1;
+            }
+            echo fread($fp, $buffer);
+
+            // Free up memory, otherwise large files will trigger PHP's memory limit
+            flush();
+        }
+
+        fclose($fp);
+    }
+}

--- a/Classes/Stream/FileStream.php
+++ b/Classes/Stream/FileStream.php
@@ -92,4 +92,9 @@ class FileStream extends SelfEmittableLazyOpenStream
 
         fclose($fp);
     }
+
+    public function getFilename(): string
+    {
+        return $this->filename;
+    }
 }


### PR DESCRIPTION
Hey @xperseguers 

the current integration of the middleware destroy the middleware stack, because headers are directly send via "header()" and the content is also sent in the middleware (incl. "exit" calls). I found the reason in the class documentation **"Note: we cannot return a standard PSR response as @see \TYPO3\CMS\Core\Http\AbstractApplication::sendResponse() will load all the content into memory using $body->__toString()"** and I found a better solution.... :-) feel free to review this.

The core (at least at all your supported versions of your extension) offer the option to add a "SelfEmittableStreamInterface" object to the Response to avoid calling "__toString()". In this case "emit" is used. https://api.typo3.org/9.5/_abstract_application_8php_source.html#l00062 There are core objects that integrate this interface, but the integrations do not support "huge files" and "partial downloads".

As solution, I created a new "FileStream" and move all the "handlePartialDownload"-stuff from the  middleware into this stream. The middleware create a valid Response object that contains this new "FileStream" and the core send the file via the Stream in the right way. Also partial Downloads are possible -> I tested this with a 80MB Video in a memory_limit 64MB Env. Works great...

These are the advantages:
- Split the stream and the middleware logic into two classes
- Keep the middleware stack consistent, so an upper middleware could add more information (in my case a CORS middleware)
- There are no more "header()"-calls in the middleware and all is handled via the Response object
- There are no more "exit" calls in the middleware

Could you send me some feedback?

This integration finish this issue https://github.com/xperseguers/t3ext-fal-protect/issues/22 and perhaps also https://github.com/xperseguers/t3ext-fal-protect/issues/29 if this is a middleware problem :-) 

Regards,
Tim
