### PR TITLE
Add recommendations for PHP settings (Issue #50)

### DIFF
--- a/Documentation/AdministratorManual/Index.rst
+++ b/Documentation/AdministratorManual/Index.rst
@@ -136,3 +136,13 @@ TYPO3):
      access_log off;
      log_not_found off;
    }
+
+
+
+Recommendations
+-----------------------
+
+PHP Settings
+^^^^^^^^
+
+In order to download large files via a PHP script, it's recommended to activate the PHP extension `opcode` for faster script execution and increase the PHP setting `merory_limit` (to 256MB for example).


### PR DESCRIPTION
When downloading a large file, PHP can run into memory overflow. Suggesting to activate opcode module and increase memory limit for downloading large files via PHP script.