### PR TITLE
[TASK] Rearange TCA fields

### DIFF
--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -76,9 +76,7 @@ if (!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('filemetadata'
             --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
             visible,
             fe_groups
-        ',
-        '',
-        'after:alternative'
+        '
     );
 }
 

--- a/Configuration/TCA/Overrides/sys_file_metadata.php
+++ b/Configuration/TCA/Overrides/sys_file_metadata.php
@@ -76,7 +76,9 @@ if (!\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::isLoaded('filemetadata'
             --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:access,
             visible,
             fe_groups
-        '
+        ',
+        '',
+        'after:title'
     );
 }
 


### PR DESCRIPTION
Rearange TCA fields for `sys_file_metadata` to the same order like without `ext:fal_protect`.

Without `ext:fal_protect` you have the following fields in the `General` tab:
- alternative
- description
- title

<img width="688" alt="Bildschirmfoto 2024-04-08 um 12 38 21" src="https://github.com/xperseguers/t3ext-fal-protect/assets/2102444/ba71e7e5-d3d5-4b62-b2e1-8a4cd7ee26d2">


Installing `ext:fal_protect` will move the fields `description` and `title` to the tab `Access`.

<img width="682" alt="Bildschirmfoto 2024-04-08 um 12 39 05" src="https://github.com/xperseguers/t3ext-fal-protect/assets/2102444/5b3e66bb-580a-4269-933a-3b2be7c535a5">
<img width="684" alt="Bildschirmfoto 2024-04-08 um 12 39 23" src="https://github.com/xperseguers/t3ext-fal-protect/assets/2102444/27ebff95-7190-4a9a-ba62-ec043dcb2a51">



This pull request restores the field order to the "default" behaviour.