### PR TITLE
[FIX] Fix pointer access to configArray

### DIFF
--- a/Classes/LinkHandling/ProtectedFileLinkHandler.php
+++ b/Classes/LinkHandling/ProtectedFileLinkHandler.php
@@ -35,7 +35,7 @@ class ProtectedFileLinkHandler extends FileLinkHandler
         // Link to file even if access is missing?
         $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
         if ($request !== null) {
-            $frontendTypoScriptConfigArray = $request->getAttribute('frontend.typoscript')?->getConfigArray();
+            $frontendTypoScriptConfigArray = $request->getAttribute('frontend.typoscript')->getConfigArray();
             if ((bool)($frontendTypoScriptConfigArray['typolinkLinkAccessRestrictedPages'] ?? false)) {
                 return $file;
             }


### PR DESCRIPTION
There was a typo here:
 $frontendTypoScriptConfigArray = $request->getAttribute('frontend.typoscript')?->getConfigArray();